### PR TITLE
Fix mysql not running from a volume

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -124,12 +124,6 @@ mysql_timer () {
 
 # mysql service management
 start_mysql () {
-    if [ ! -d /var/lib/mysql/mysql ]; then
-        echo -n " * Initializing MYSQL database for the first time"
-        mysqld --initialize-insecure
-    else
-        rm /var/run/mysqld/mysqld.sock.lock
-    fi
     # determine if we are running mariadb or mysql then guess pid location
     if [ $(mysql --version |grep -ci mariadb) -ge "1" ]; then
         default_pidfile="/var/run/mariadb/mariadb.pid"
@@ -142,6 +136,12 @@ start_mysql () {
     mypidfile=$result
     mypidfolder=${mypidfile%/*}
 
+    if [ ! -d /var/lib/mysql/mysql ]; then
+        echo -n " * Initializing MYSQL database for the first time"
+        mysqld --initialize-insecure
+    else
+        rm ${mypidfolder}/mysqld.sock.lock
+    fi
     # Start mysql only if it is not already running
     if [ "$(mysql_running)" -eq "0" ]; then
         echo -n " * Starting MySQL database server service"

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -146,10 +146,10 @@ start_mysql () {
     mysocklockfile=${mypidfile%/mysqld.sock.lock}
 
     if [ "$(mysql_datadir_exists)" -eq "0" ]; then
-        echo -n " * First run of MYSQL, initializing DB."
+        echo " * First run of MYSQL, initializing DB."
         mysqld --initialize-insecure
     elif [ -e ${mypidsocklock} ]; then
-        echo -n " * Removing stale lock file"
+        echo " * Removing stale lock file"
         rm -f ${mypidsocklock}
     fi
     # Start mysql only if it is not already running

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -124,6 +124,10 @@ mysql_timer () {
 
 # mysql service management
 start_mysql () {
+    if [ ! -d /var/lib/mysql/mysql ]; then
+        echo -n " * Initializing MYSQL database for the first time"
+        mysqld --initialize-insecure
+    fi
     # determine if we are running mariadb or mysql then guess pid location
     if [ $(mysql --version |grep -ci mariadb) -ge "1" ]; then
         default_pidfile="/var/run/mariadb/mariadb.pid"
@@ -209,6 +213,7 @@ if [ -f /etc/timezone ]; then
     echo "$TZ" > /etc/timezone
 fi
 
+chown -R mysql:mysql /var/lib/mysql/
 # Configure then start Mysql
 if [ -n "$MYSQL_SERVER" ] && [ -n "$MYSQL_USER" ] && [ -n "$MYSQL_PASSWORD" ] && [ -n "$MYSQL_DB" ]; then
     sed -i -e "s/ZM_DB_NAME=zm/ZM_DB_NAME=$MYSQL_USER/g" $ZMCONF

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -127,6 +127,8 @@ start_mysql () {
     if [ ! -d /var/lib/mysql/mysql ]; then
         echo -n " * Initializing MYSQL database for the first time"
         mysqld --initialize-insecure
+    else
+        rm /var/run/mysqld/mysqld.sock.lock
     fi
     # determine if we are running mariadb or mysql then guess pid location
     if [ $(mysql --version |grep -ci mariadb) -ge "1" ]; then

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -204,6 +204,7 @@ cleanup () {
     kill $mysqlpid > /dev/null 2>&1
     $HTTPBIN -k stop > /dev/null 2>&1
     sleep 5
+    exit 0
 }
 
 ################
@@ -259,6 +260,6 @@ start_zoneminder
 while :
 do
     # perhaps output some stuff here or check apache & mysql are still running
-    sleep 3600
+    sleep 2
 done
 


### PR DESCRIPTION
When running the container with a host-mounted volume for `/var/lib/mysql`, special care must be taken to initialize the directory and make sure it has the right permissions.

The idea was recommended to me in the FreeNode "#docker" channel. It is also applied in the official mysql container:
https://github.com/docker-library/mysql/blob/master/5.6/docker-entrypoint.sh#L70
https://github.com/docker-library/mysql/blob/master/5.6/docker-entrypoint.sh#L80