### PR TITLE
Fix zm_create.sql sourcing relative sql file

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -53,6 +53,7 @@ initialize () {
     for FILE in "/usr/share/zoneminder/db/zm_create.sql" "/usr/local/share/zoneminder/db/zm_create.sql"; do
         if [ -f $FILE ]; then
             ZMCREATE=$FILE
+            sed -i 's|/db/triggers.sql|triggers.sql|' "$ZMCREATE"
             break
         fi
     done
@@ -249,7 +250,10 @@ else
     start_mysql
     if [ "$(zm_db_exists)" -eq "0" ]; then
         echo " * First run of mysql in the container, creating zoneminder tables."
-        mysql -u root < $ZMCREATE
+        pushd . >/dev/null
+        cd "$(dirname "$ZMCREATE")"
+        echo "source $(basename "$ZMCREATE")" | mysql -u root
+        popd >/dev/null
     else
         echo " * ZoneMinder dB already exists, skipping table creation."
     fi


### PR DESCRIPTION
When trying to build development, I kept getting

    Failed to open file '/db/triggers.sql', error: 2

I tracked it down to [entrypoint.sh:252](https://github.com/ZoneMinder/zmdockerfiles/blob/1a3c964831aa1edb1015dce6e490a68e3f1e096b/utils/entrypoint.sh#L252), which sources zm_create.sql. On the ubuntu container, this is in `/usr/local/share/zoneminder/zm_create.sh`, which sources `/db/triggers.sql` on line 498:

    ...
    -- We generally don't alter triggers, we drop and re-create them, so let's keep them in a separate file that we can just source in update scripts.
    source /db/triggers.sql
    ...

Since this is an absolute path, MySQL isn't able to find triggers.sql given the above path, so I add a sed command to change `/db/triggers.sql` to `triggers.sql`.

However, MySQL `source` works relative to the current directory, not the current sql file being sourced. When zm_create.sql sources triggers.sql, MySQL looks relative to the current directory. So I added `pushd`/`popd` to cd into the directory that zm_create.sql resides in before sourcing it, and then cd back when done.