### PR TITLE
Don't silently fail in entrypoint.sh

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -11,6 +11,9 @@
 ###############
 
 # Find ciritical files and perform sanity checks
+
+set -e
+
 initialize () {
 
     # Check to see if this script has access to all the commands it needs


### PR DESCRIPTION
While diagnosing #7, I realized that the container was being successfully created even though commands in entrypoint.sh were failing. Previously, a command in entrypoint.sh could fail (return a non-zero exit code) and it would be ignored. Since entrypoint.sh wouldn't exit with a non-zero, the docker container would build successfully build, even though it may be incomplete (e.g. see #7, the database wasn't properly initialized, which led to hard to diagnose errors after container creation).