### PR TITLE
Fix parameter for mysql_install_db

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -184,7 +184,7 @@ start_mysql () {
 
     if [ "$(mysql_datadir_exists)" -eq "0" ]; then
         echo " * First run of MYSQL, initializing DB."
-        mysql_install_db --user=mysql --ldata=/var/lib/mysql/ > /dev/null 2>&1
+        mysql_install_db --user=mysql --datadir=/var/lib/mysql/ > /dev/null 2>&1
     elif [ -e ${mypidsocklock} ]; then
         echo " * Removing stale lock file"
         rm -f ${mypidsocklock}


### PR DESCRIPTION
According to https://dev.mysql.com/doc/refman/5.7/en/mysql-install-db.html,
the parameter `--ldata` was removed in mysql 5.7.5. Since it was just a
synonym for `--datadir`, we use that parameter instead.

This fixes the creation of a mysql database for the
`development/ubuntu/xenial` case, where the mysql version is already too
recent to have `--ldata` (currently Ver 5.7.23).