### PR TITLE
fixes #16

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -14,7 +14,7 @@
 initialize () {
 
     # Check to see if this script has access to all the commands it needs
-    for CMD in cat grep install ln my_print_defaults mysql mysqladmin mysqld_safe mysql_install_db mysqlshow sed sleep su tail usermod; do
+    for CMD in cat grep install ln my_print_defaults mysql mysqladmin mysqld_safe mysqlshow sed sleep su tail usermod; do
       type $CMD &> /dev/null
 
       if [ $? -ne 0 ]; then
@@ -184,7 +184,7 @@ start_mysql () {
 
     if [ "$(mysql_datadir_exists)" -eq "0" ]; then
         echo " * First run of MYSQL, initializing DB."
-        mysql_install_db --user=mysql --datadir=/var/lib/mysql/ > /dev/null 2>&1
+        /usr/sbin/mysqld --initialize-insecure --user=mysql --datadir=/var/lib/mysql/ > /dev/null 2>&1
     elif [ -e ${mypidsocklock} ]; then
         echo " * Removing stale lock file"
         rm -f ${mypidsocklock}


### PR DESCRIPTION
mysql_install_db is deprecated as of MySQL 5.7.6 (https://dev.mysql.com/doc/refman/5.7/en/mysql-install-db.html).
it is no londer needed. i've replaced it to fix.