### PR TITLE
Shrink release image size by 21%

### DIFF
--- a/release/el7/Dockerfile
+++ b/release/el7/Dockerfile
@@ -8,6 +8,8 @@ RUN \
   && yum -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm \
   # Install the latest *release* of zoneminder
   && yum -y install zoneminder mariadb-server mod_ssl zip file \
+  # Clean up yum cache
+  && yum clean all \
   # Configure Apache
   && ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/ \
   && echo "ServerName localhost" > /etc/httpd/conf.d/servername.conf \

--- a/release/el7/Dockerfile
+++ b/release/el7/Dockerfile
@@ -4,21 +4,25 @@ MAINTAINER Andrew Bauer <zonexpertconsulting@outlook.com>
 # Get the entrypoint script
 ADD https://raw.githubusercontent.com/ZoneMinder/zmdockerfiles/master/utils/entrypoint.sh /usr/local/bin/
 
+## Dependencies layer
 RUN \
   # Enable the EPEL repo. The repo package is part of centos base so no need fetch it.
   yum -y install epel-release \
   # Fetch and enable the RPMFusion repo
   && yum -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm \
-  # Install the latest *release* of zoneminder
-  && yum -y install zoneminder mariadb-server mod_ssl zip file \
+  # Install dependencies
+  && yum -y install mariadb-server mod_ssl zip file \
   # Clean up yum cache
   && yum clean all \
-  # Configure Apache
-  && ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/ \
-  && echo "ServerName localhost" > /etc/httpd/conf.d/servername.conf \
-  && echo -e "# Redirect the webroot to /zm\nRedirectMatch permanent ^/$ /zm" > /etc/httpd/conf.d/redirect.conf \
   # Make sure the entrypoint is executable
   && chmod 755 /usr/local/bin/entrypoint.sh
+
+## ZoneMinder layer
+RUN \
+  # Install the latest *release* of zoneminder
+  yum -y install zoneminder \
+  # Clean up yum cache
+  && yum clean all
 
 # Set our volumes before we do anything else
 VOLUME /var/lib/zoneminder/images /var/lib/zoneminder/events /var/lib/mysql /var/log/zoneminder

--- a/release/el7/Dockerfile
+++ b/release/el7/Dockerfile
@@ -1,29 +1,28 @@
 FROM centos:7
 MAINTAINER Andrew Bauer <zonexpertconsulting@outlook.com>
 
-# Enable the EPEL repo. The repo package is part of centos base so no need fetch it.
-RUN yum -y install epel-release
+RUN \
+  # Enable the EPEL repo. The repo package is part of centos base so no need fetch it.
+  yum -y install epel-release \
+  # Fetch and enable the RPMFusion repo
+  && yum -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm \
+  # Install the latest *release* of zoneminder
+  && yum -y install zoneminder mariadb-server mod_ssl zip file \
+  # Configure Apache
+  && ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/ \
+  && echo "ServerName localhost" > /etc/httpd/conf.d/servername.conf \
+  && echo -e "# Redirect the webroot to /zm\nRedirectMatch permanent ^/$ /zm" > /etc/httpd/conf.d/redirect.conf \
+  # Make sure the entrypoint is executable
+  && chmod 755 /usr/local/bin/entrypoint.sh
 
-# Fetch and enable the RPMFusion repo
-RUN yum -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
-
-# Install the latest *release* of zoneminder
-RUN yum -y install zoneminder mariadb-server mod_ssl zip file
-
-# Set our volumes before we attempt to configure apache
+# Set our volumes before we do anything else
 VOLUME /var/lib/zoneminder/images /var/lib/zoneminder/events /var/lib/mysql /var/log/zoneminder
 
-# Configure Apache
-RUN ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/
-RUN echo "ServerName localhost" > /etc/httpd/conf.d/servername.conf
-RUN echo -e "# Redirect the webroot to /zm\nRedirectMatch permanent ^/$ /zm" > /etc/httpd/conf.d/redirect.conf
+# Get the entrypoint script
+ADD https://raw.githubusercontent.com/ZoneMinder/zmdockerfiles/master/utils/entrypoint.sh /usr/local/bin/
 
 # Expose https port
 EXPOSE 443
-
-# Get the entrypoint script and make sure it is executable
-ADD https://raw.githubusercontent.com/ZoneMinder/zmdockerfiles/master/utils/entrypoint.sh /usr/local/bin/
-RUN chmod 755 /usr/local/bin/entrypoint.sh
 
 # This is run each time the container is started
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/release/el7/Dockerfile
+++ b/release/el7/Dockerfile
@@ -1,6 +1,9 @@
 FROM centos:7
 MAINTAINER Andrew Bauer <zonexpertconsulting@outlook.com>
 
+# Get the entrypoint script
+ADD https://raw.githubusercontent.com/ZoneMinder/zmdockerfiles/master/utils/entrypoint.sh /usr/local/bin/
+
 RUN \
   # Enable the EPEL repo. The repo package is part of centos base so no need fetch it.
   yum -y install epel-release \
@@ -19,9 +22,6 @@ RUN \
 
 # Set our volumes before we do anything else
 VOLUME /var/lib/zoneminder/images /var/lib/zoneminder/events /var/lib/mysql /var/log/zoneminder
-
-# Get the entrypoint script
-ADD https://raw.githubusercontent.com/ZoneMinder/zmdockerfiles/master/utils/entrypoint.sh /usr/local/bin/
 
 # Expose https port
 EXPOSE 443


### PR DESCRIPTION
In an effort to make as small of a release image as possible (using official base images, i.e., centos:7), I reorganized the Dockerfile to minimize the number of layers in the final image, and told yum to clear its cache. Final image is now 776 MB (down from 984 MB)

Combining the following lines into a single `RUN` command decreased the final image by 94 MB:
```
# Enable the EPEL repo. The repo package is part of centos base so no need fetch it.
RUN yum -y install epel-release

# Fetch and enable the RPMFusion repo
RUN yum -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm

# Install the latest *release* of zoneminder
RUN yum -y install zoneminder mariadb-server mod_ssl zip file
```
... all other `RUN` commands were also combined into the single `RUN`, but did not decrease image size significantly (total decrease < 1 MB); however they removed an extra 5 layers from the image.

Removing the yum cache, `yum clean all`, reduced the final image another 114 MB.

Currently, I have commits for each step with the output of `docker image` and `docker history` to trace the changes in the layers and final image. I can squash these if needed. The build history from the current master, 39840d2, for comparison is below.

```
$ docker image zm/zm
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
zm/zm               latest              7eddcf1baf65        About a minute ago   984MB
```

```
$ docker history zm/zm
IMAGE               CREATED              CREATED BY                                      SIZE                COMMENT
7eddcf1baf65        About a minute ago   /bin/sh -c #(nop)  ENTRYPOINT ["/usr/local/b…   0B
ba1073ed41d1        About a minute ago   /bin/sh -c chmod 755 /usr/local/bin/entrypoi…   11.3kB
82a6774a770a        About a minute ago   /bin/sh -c #(nop) ADD 781096b652e6a5210b2d70…   11.3kB
a728b978ab09        About a minute ago   /bin/sh -c #(nop)  EXPOSE 443                   0B
68e5bf14320c        About a minute ago   /bin/sh -c echo -e "# Redirect the webroot t…   62B
0d03ddcab997        About a minute ago   /bin/sh -c echo "ServerName localhost" > /et…   21B
260cbb904365        About a minute ago   /bin/sh -c ln -sf /etc/zm/www/zoneminder.con…   27B
058a2ba7c4eb        About a minute ago   /bin/sh -c #(nop)  VOLUME [/var/lib/zonemind…   0B
16e73b66d462        About a minute ago   /bin/sh -c yum -y install zoneminder mariadb…   688MB
90b4cc590d61        9 minutes ago        /bin/sh -c yum -y localinstall --nogpgcheck …   23.5MB
33aa85535bc5        9 minutes ago        /bin/sh -c yum -y install epel-release          70.1MB
d65ff6699d01        19 minutes ago       /bin/sh -c #(nop)  MAINTAINER Andrew Bauer <…   0B
1e1148e4cc2c        3 days ago           /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>           3 days ago           /bin/sh -c #(nop)  LABEL org.label-schema.sc…   0B
<missing>           3 days ago           /bin/sh -c #(nop) ADD file:6f877549795f4798a…   202MB
```