### PR TITLE
Set permissions on volumes defined in the Dockerfile

### DIFF
--- a/release/el7/Dockerfile
+++ b/release/el7/Dockerfile
@@ -12,6 +12,9 @@ RUN yum -y install zoneminder mariadb-server mod_ssl zip file
 
 # Set our volumes before we attempt to configure apache
 VOLUME /var/lib/zoneminder/images /var/lib/zoneminder/events /var/lib/mysql /var/log/zoneminder
+# Set appropriate owners on VOLUMEs
+RUN  chown apache:apache /var/lib/zoneminder/images /var/lib/zoneminder/events /var/log/zoneminder \
+  && chown mysql:mysql /var/lib/mysql
 
 # Configure Apache
 RUN ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/

--- a/release/el7/Dockerfile
+++ b/release/el7/Dockerfile
@@ -13,8 +13,7 @@ RUN yum -y install zoneminder mariadb-server mod_ssl zip file
 # Set our volumes before we attempt to configure apache
 VOLUME /var/lib/zoneminder/images /var/lib/zoneminder/events /var/lib/mysql /var/log/zoneminder
 # Set appropriate owners on VOLUMEs
-RUN  chown apache:apache /var/lib/zoneminder/images /var/lib/zoneminder/events /var/log/zoneminder \
-  && chown mysql:mysql /var/lib/mysql
+RUN  chown apache:apache /var/lib/zoneminder/images /var/lib/zoneminder/events /var/log/zoneminder
 
 # Configure Apache
 RUN ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -326,7 +326,6 @@ if [ -f /etc/timezone ]; then
     echo "$TZ" > /etc/timezone
 fi
 
-chown -R mysql:mysql /var/lib/mysql/
 # Configure then start Mysql
 if [ "$remoteDB" -eq "1" ]; then
     sed -i -e "s/ZM_DB_NAME=.*$/ZM_DB_NAME=$ZM_DB_NAME/g" $ZMCONF

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -326,7 +326,10 @@ if [ -f /etc/timezone ]; then
     echo "$TZ" > /etc/timezone
 fi
 
+# Set permissions
 chown -R mysql:mysql /var/lib/mysql/
+chown -R apache:apache /var/lib/zoneminder/events /var/lib/zoneminder/images /var/log/zoneminder
+
 # Configure then start Mysql
 if [ "$remoteDB" -eq "1" ]; then
     sed -i -e "s/ZM_DB_NAME=.*$/ZM_DB_NAME=$ZM_DB_NAME/g" $ZMCONF

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -326,10 +326,7 @@ if [ -f /etc/timezone ]; then
     echo "$TZ" > /etc/timezone
 fi
 
-# Set permissions
 chown -R mysql:mysql /var/lib/mysql/
-chown -R apache:apache /var/lib/zoneminder/events /var/lib/zoneminder/images /var/log/zoneminder
-
 # Configure then start Mysql
 if [ "$remoteDB" -eq "1" ]; then
     sed -i -e "s/ZM_DB_NAME=.*$/ZM_DB_NAME=$ZM_DB_NAME/g" $ZMCONF


### PR DESCRIPTION
`VOLUME`s defined in the Dockerfile will get root:root ownership in the
container. This will lead to the following message on startup:
`Cannot write to content dirs('/var/lib/zoneminder/events',
'/var/lib/zoneminder/images'). Check that these exist and are
owned by the web account user`. Eventually, the same will happen for
`/var/lib/zoneminder/images` and `/var/log/zoneminder`

I added the permission changing `chown` to the entrypoint script. I
did this in the entrypoint, and not the build, because even if this was
set in build, if a user bind mounts a volume (definitely docker-compose;
not sure about just docker), it will end up as root anyway. Best to do
in the entrypoint.