### PR TITLE
Combined Apache config RUNs into ZoneMinder install RUN

### DIFF
--- a/release/el7/Dockerfile
+++ b/release/el7/Dockerfile
@@ -22,15 +22,14 @@ RUN \
   # Install the latest *release* of zoneminder
   yum -y install zoneminder \
   # Clean up yum cache
-  && yum clean all
+  && yum clean all \
+  # Configure Apache
+  && ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/ \
+  && echo "ServerName localhost" > /etc/httpd/conf.d/servername.conf \
+  && echo -e "# Redirect the webroot to /zm\nRedirectMatch permanent ^/$ /zm" > /etc/httpd/conf.d/redirect.conf
 
 # Set our volumes before we do anything else
 VOLUME /var/lib/zoneminder/images /var/lib/zoneminder/events /var/lib/mysql /var/log/zoneminder
-
-# Configure Apache
-RUN ln -sf /etc/zm/www/zoneminder.conf /etc/httpd/conf.d/
-RUN echo "ServerName localhost" > /etc/httpd/conf.d/servername.conf
-RUN echo -e "# Redirect the webroot to /zm\nRedirectMatch permanent ^/$ /zm" > /etc/httpd/conf.d/redirect.conf
 
 # Expose https port
 EXPOSE 443


### PR DESCRIPTION
PR made to combine the Apache config `RUN` directives added by #30. 

Apache functions as expected now; tested with `docker run --rm -p 444:443 test/zm/fix-combine-missed-apache-runs`

Final image size is 800MB:
```
$ docker images test/zm/fix-combine-missed-apache-runs
REPOSITORY                               TAG                 IMAGE ID            CREATED             SIZE
test/zm/fix-combine-missed-apache-runs   latest              ad9fa198ceba        38 seconds ago      800MB
```

Image layers are now as follows:
```
$ docker history test/zm/fix-combine-missed-apache-runs
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
ad9fa198ceba        55 seconds ago      /bin/sh -c #(nop)  ENTRYPOINT ["/usr/local/b…   0B
c6ab927ec4eb        56 seconds ago      /bin/sh -c #(nop)  EXPOSE 443                   0B
e05bfcb50b72        57 seconds ago      /bin/sh -c #(nop)  VOLUME [/var/lib/zonemind…   0B
a0c6468f5ec7        58 seconds ago      /bin/sh -c yum -y install zoneminder   && yu…   386MB
ed3a3e040c5e        5 days ago          /bin/sh -c yum -y install epel-release   && …   212MB
7ad6b0ce0857        5 days ago          /bin/sh -c #(nop) ADD 781096b652e6a5210b2d70…   11.3kB
e9f51a14b1d7        5 days ago          /bin/sh -c #(nop)  MAINTAINER Andrew Bauer <…   0B
1e1148e4cc2c        12 days ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>           12 days ago         /bin/sh -c #(nop)  LABEL org.label-schema.sc…   0B
<missing>           12 days ago         /bin/sh -c #(nop) ADD file:6f877549795f4798a…   202MB
```