### PR TITLE
Docker image for debian 10

### DIFF
--- a/release/debian10/DockerFile
+++ b/release/debian10/DockerFile
@@ -1,0 +1,13 @@
+FROM debian:10
+ 
+RUN apt-get update ; apt-get install -y gnupg apt-transport-https  wget ca-certificates; echo "deb [trusted=yes] https://zmrepo.zoneminder.com/debian/release-1.34 buster/" >> etc/apt/sources.list; wget -O - https://zmrepo.zoneminder.com/debian/archive-keyring.gpg | apt-key add -; apt-get update; apt-get -y install zoneminder; apt-get remove --purge -y $BUILD_PACKAGES $(apt-mark showauto) && rm -rf /var/lib/apt/lists/*; adduser www-data video; systemctl enable zoneminder.service; a2enconf zoneminder; a2enmod rewrite
+# Setup Volumes
+VOLUME /var/cache/zoneminder/events /var/cache/zoneminder/images /var/lib/mysql /var/log/zm
+
+# Expose http port
+EXPOSE 80
+
+# Configure entrypoint
+COPY utils/entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/release/debian10/README.md
+++ b/release/debian10/README.md
@@ -1,0 +1,17 @@
+# Usage
+
+The Docker images are available from the Docker Hub e.g.
+
+```bash
+docker run -d -t -p 1080:80 \
+    -e TZ='Europe/London' \
+    -v ~/zoneminder/events:/var/cache/zoneminder/events \
+    -v ~/zoneminder/images:/var/cache/zoneminder/images \
+    -v ~/zoneminder/mysql:/var/lib/mysql \
+    -v ~/zoneminder/logs:/var/log/zm \
+    --shm-size="512m" \
+    --name zoneminder \
+    zoneminderhq/zoneminder:debian10
+```
+
+Once the container is running you will need to browse to http://hostname:port/zm to access the Zoneminder interface.


### PR DESCRIPTION
Built following the directions from https://wiki.zoneminder.com/Debian_10_Buster_with_Zoneminder_1.34.x_from_ZM_Repo