### PR TITLE
minor improvements to Ubuntu image

### DIFF
--- a/release/ubuntu18.04/Dockerfile
+++ b/release/ubuntu18.04/Dockerfile
@@ -2,21 +2,16 @@ FROM ubuntu:18.04
 MAINTAINER Peter Gallagher
 
 # Update base packages
-RUN apt update \
-    && apt upgrade --assume-yes
-
-# Install pre-reqs
-RUN apt install --assume-yes --no-install-recommends gnupg
-
-# Configure Zoneminder PPA
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABE4C7F993453843F0AEB8154D0BF748776FFB04 \
+RUN apt-get update \
+    && apt-get upgrade -y ; \ 
+    apt-get install -y --no-install-recommends gnupg ; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABE4C7F993453843F0AEB8154D0BF748776FFB04 \
     && echo deb http://ppa.launchpad.net/iconnor/zoneminder-1.32/ubuntu bionic main > /etc/apt/sources.list.d/zoneminder.list \
-    && apt update
-
-# Install zoneminder
-RUN DEBIAN_FRONTEND=noninteractive apt install --assume-yes zoneminder \
+    && apt-get update ; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y zoneminder \
     && a2enconf zoneminder \
-    && a2enmod rewrite cgi
+    && a2enmod rewrite cgi; \
+    apt-get remove --purge -y $BUILD_PACKAGES $(apt-mark showauto) && rm -rf /var/lib/apt/lists/*;
 
 # Setup Volumes
 VOLUME /var/cache/zoneminder/events /var/cache/zoneminder/images /var/lib/mysql /var/log/zm


### PR DESCRIPTION
Reduces number of layers in end docker file as well as cleaning up cache files from apt. uses apt-get as apt doesn't have a stable cli at this time