### PR TITLE
Upgrade to 1.36 PPA

### DIFF
--- a/release/ubuntu18.04/Dockerfile
+++ b/release/ubuntu18.04/Dockerfile
@@ -10,7 +10,7 @@ RUN apt install --assume-yes --no-install-recommends gnupg
 
 # Configure Zoneminder PPA
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABE4C7F993453843F0AEB8154D0BF748776FFB04 \
-    && echo deb http://ppa.launchpad.net/iconnor/zoneminder-1.34/ubuntu bionic main > /etc/apt/sources.list.d/zoneminder.list \
+    && echo deb http://ppa.launchpad.net/iconnor/zoneminder-1.36/ubuntu bionic main > /etc/apt/sources.list.d/zoneminder.list \
     && apt update
 
 # Install zoneminder


### PR DESCRIPTION
Update the ubuntu18.04 Dockerfile to use the [ppa:iconnor/zoneminder-1.36 PPA](https://launchpad.net/~iconnor/+archive/ubuntu/zoneminder-1.36) in order to install [ZoneMinder 1.36](https://github.com/ZoneMinder/zoneminder/releases/tag/1.36.1)