### PR TITLE
Switch from CentOS Linux 8 to Rocky Linux 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Docker files used in various ways for the ZoneMinder pr
 
 Docker images are published to Docker Hub and can be pulled directly from there e.g.
 
-### CentOS
+### CentOS and Rocky
 
 Using external folders:
 ```bash

--- a/buildsystem/rhel/el-8/Dockerfile
+++ b/buildsystem/rhel/el-8/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM rockylinux/rockylinux:8
 MAINTAINER Andrew Bauer <zonexpertconsulting@outlook.com>
 
 # Fix dnf best candidate failures
@@ -12,10 +12,10 @@ RUN dnf -y install wget dnf-utils
 RUN dnf -y install epel-release
 # added PowerTools as suggested at:
 #   https://fedoraproject.org/wiki/EPEL
-RUN dnf config-manager --set-enabled PowerTools
+RUN dnf config-manager --set-enabled powertools
 
 # Repository for building/testing dependencies that are not present in vanilla
-# CentOS and PowerTools / EPEL repositories, e.g. some Python 2 packages
+# Rocky Linux and PowerTools / EPEL repositories, e.g. some Python 2 packages
 # - fix missing locales
 ENV LC_ALL="C" LANG="en_US.UTF-8"
 # - install the backport repository

--- a/release/el8/Dockerfile
+++ b/release/el8/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM rockylinux/rockylinux:8
 MAINTAINER Andrew Bauer <zonexpertconsulting@outlook.com>
 
 # Get the entrypoint script
@@ -8,7 +8,7 @@ ADD https://raw.githubusercontent.com/ZoneMinder/zmdockerfiles/master/utils/entr
 RUN \
   # Enable PowerTools repository to reach all required dependencies
   dnf -y install 'dnf-command(config-manager)' && dnf config-manager --set-enabled powertools \
-  # Enable the EPEL repo. The repo package is part of centos base so no need fetch it.
+  # Enable the EPEL repo. The repo package is part of Rocky base so no need fetch it.
   && dnf -y install epel-release \
   # Fetch and enable the RPMFusion repo
   && dnf -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm \

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -309,7 +309,7 @@ chk_remote_mysql () {
 # Apache service management
 start_http () {
 
-    # CentOS 8 ships with php-fpm enabled, we need to start it
+    # CentOS/Rocky 8 ships with php-fpm enabled, we need to start it
     # Not tested on other distros please provide feedback
     if [ -n "$PHPFPM" ]; then
         echo -n " * Starting php-fpm web service"


### PR DESCRIPTION
Red Hat decided to end the support of CentOS Linux 8 on 2021-12-31, while shifting the focus to CentOS Stream 8 as upstream development for Red Hat Enterprise Linux only. Rocky Linux 8 is designed to be 100% bug-for-bug compatible with Red Hat Enterprise Linux 8.