### PR TITLE
Install support for hardware accelerator decoder devices

### DIFF
--- a/release/el8/Dockerfile
+++ b/release/el8/Dockerfile
@@ -14,6 +14,8 @@ RUN \
   && dnf -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm \
   # Install dependencies
   && dnf -y install mariadb-server mod_ssl zip file \
+  # Install support for hardware accelerator decoder devices
+  && dnf -y install mesa-dri-drivers libva-intel-driver \
   # Clean up dnf cache
   && dnf clean all \
   # Make sure the entrypoint is executable


### PR DESCRIPTION
Using DecoderHWAccelName/DecoderHWAccelDevice in ZoneMinder with `podman/docker [...] --device /dev/dri [...]` requires the drivers for at least common devices inside the container image.

This is meant to address more or less the same issue like https://github.com/ZoneMinder/zoneminder/issues/3063, but for CentOS/Rocky Linux 8 rather for Ubuntu.